### PR TITLE
Fix 0 SL Opposed / Unopposed Tests

### DIFF
--- a/src/system/tests/opposed-result.js
+++ b/src/system/tests/opposed-result.js
@@ -20,6 +20,54 @@ export class OpposedTestResult
         {
             this.winner = "defender";
         }
+        else {
+            // If both parties in an Opposed Test get the same SL, the character with the higher Skill wins
+            if (defenderTest)
+            {
+                const getSkillSpecTotal = test =>
+                {
+                    let skillObject;
+                    if (typeof test.skill == "string")
+                    {
+                        skillObject = test.actor.system.skills[test.skill];
+                    }
+                    else if (test.skill instanceof Item)
+                    {
+                        skillObject = test.skill.system;
+                    }
+                    else if (typeof test.skill == "object")
+                    {
+                        skillObject = test.skill;
+                    }
+                    return skillObject.getTotalFor(skillObject.characteristic, test.actor);
+                };
+                
+                let attackerSkillTotal = getSkillSpecTotal(attackerTest);
+                let defenderSkillTotal = getSkillSpecTotal(defenderTest);
+
+                if (attackerSkillTotal > defenderSkillTotal)
+                {
+                    this.winner = "attacker";
+                }
+                else if (attackerSkillTotal < defenderSkillTotal)
+                {
+                    this.winner = "defender";
+                }
+                // GM decides in event of skill tie
+            }
+            // If Unopposed, use the outcome of the attacker test to determine winner
+            else
+            {
+                if (attackerTest.result.outcome == "success")
+                {
+                    this.winner = "attacker";
+                }
+                else
+                {
+                    this.winner = "defender";
+                }
+            }
+        }
 
         if (this.winner == "attacker" && attackerTest.item && this.constructor.damagingItems.includes(attackerTest.item?.type))
         {

--- a/src/system/tests/opposed-result.js
+++ b/src/system/tests/opposed-result.js
@@ -20,30 +20,13 @@ export class OpposedTestResult
         {
             this.winner = "defender";
         }
-        else {
+        else if (this.SL == 0)
+        {
             // If both parties in an Opposed Test get the same SL, the character with the higher Skill wins
             if (defenderTest)
             {
-                const getSkillSpecTotal = test =>
-                {
-                    let skillObject;
-                    if (typeof test.skill == "string")
-                    {
-                        skillObject = test.actor.system.skills[test.skill];
-                    }
-                    else if (test.skill instanceof Item)
-                    {
-                        skillObject = test.skill.system;
-                    }
-                    else if (typeof test.skill == "object")
-                    {
-                        skillObject = test.skill;
-                    }
-                    return skillObject.getTotalFor(skillObject.characteristic, test.actor);
-                };
-                
-                let attackerSkillTotal = getSkillSpecTotal(attackerTest);
-                let defenderSkillTotal = getSkillSpecTotal(defenderTest);
+                let attackerSkillTotal = attackerTest.computeTarget(true);
+                let defenderSkillTotal = defenderTest.computeTarget(true);
 
                 if (attackerSkillTotal > defenderSkillTotal)
                 {
@@ -58,7 +41,7 @@ export class OpposedTestResult
             // If Unopposed, use the outcome of the attacker test to determine winner
             else
             {
-                if (attackerTest.result.outcome == "success")
+                if (attackerTest.succeeded)
                 {
                     this.winner = "attacker";
                 }


### PR DESCRIPTION
Fixes 0 SL Unopposed Tests to use the outcome of the attacking test to determine winner.

Adds Skill/Spec comparison in the event of 0 SL on an Opposed Test, according to the sidebar on Core Rulebook pg. 190 "If both parties in an Opposed Test get the same SL, the character with the higher Skill wins. In the unlikely event of a tie, the GM decides the outcome."

Unopposed 0SL Test:
![unopposed0slfixed](https://github.com/moo-man/ImpMal-FoundryVTT/assets/162483778/bd033565-e40c-4b8e-85b7-97fe51c5495a)

Opposed 0SL Test, result determined by higher skill, attacker has 55 Melee (One-handed) vs 50:
![opposed0slfixed](https://github.com/moo-man/ImpMal-FoundryVTT/assets/162483778/a050d7e1-f61f-4869-b549-5ce358cf4a4d)

Another Opposed 0SL Test in the defender's favour: 
![image](https://github.com/moo-man/ImpMal-FoundryVTT/assets/162483778/28a228e0-4634-423d-a02c-a3ff9f0e2010)
