### PR TITLE
fix: Fix typo in test difficulty

### DIFF
--- a/src/system/config.js
+++ b/src/system/config.js
@@ -263,7 +263,7 @@ const IMPMAL = {
         },
         difficult : {
             modifier : -10,
-            name : "IMPMAL.DifficultTerrain"
+            name : "IMPMAL.Difficult"
         },
         hard: {
             modifier : -20,


### PR DESCRIPTION
There is a typo in test difficulty selector where -10 test is using IMPMAL.DifficultTerrain instead of IMPMAL.Difficult translation key.