### PR TITLE
Fix https://github.com/moo-man/ImpMal-FoundryVTT/issues/154 Allow empty characteristic for ranged weapon damage 

### DIFF
--- a/static/templates/item/partials/item-damage.hbs
+++ b/static/templates/item/partials/item-damage.hbs
@@ -4,8 +4,7 @@
         <input type="text" value="{{system.damage.base}}" name="system.damage.base">
         +
         <select name="system.damage.characteristic">
-            <option value="">{{localize "IMPMAL.None"}}</option>
-            {{selectOptions (config "characteristicAbbrev") selected=system.damage.characteristic}}
+            {{selectOptions (config "characteristicAbbrev") selected=system.damage.characteristic blank=""}}
         </select>
         {{#unless hideSL}}
             <input type="checkbox" name="system.damage.SL" {{checked system.damage.SL}}>


### PR DESCRIPTION
Adds a "None" option to the dropdown for weapon damage modifiers, fix for https://github.com/moo-man/ImpMal-FoundryVTT/issues/154

<img width="363" height="485" alt="image" src="https://github.com/user-attachments/assets/1e235359-82e2-4a29-be6e-34418c35d0d4" />
 