### PR TITLE
Fix/modifications and custom ammo "https://github.com/moo-man/ImpMal-FoundryVTT/issues/155"

### DIFF
--- a/src/system/tests/attack/attack-test.js
+++ b/src/system/tests/attack/attack-test.js
@@ -37,7 +37,7 @@ export class AttackTest extends SkillTest
 
     get itemTraits() 
     {
-	return (this.item.system.traits || this.item.system.attack?.traits);
+		return (this.item.system.traits || this.item.system.attack?.traits);
     }
 
 

--- a/src/system/tests/attack/attack-test.js
+++ b/src/system/tests/attack/attack-test.js
@@ -37,7 +37,7 @@ export class AttackTest extends SkillTest
 
     get itemTraits() 
     {
-        return (this.item.system.traits || this.item.system.attack?.traits)?.clone();
+	return (this.item.system.traits || this.item.system.attack?.traits);
     }
 
 

--- a/static/templates/item/partials/item-damage.hbs
+++ b/static/templates/item/partials/item-damage.hbs
@@ -4,6 +4,7 @@
         <input type="text" value="{{system.damage.base}}" name="system.damage.base">
         +
         <select name="system.damage.characteristic">
+            <option value="">{{localize "IMPMAL.None"}}</option>
             {{selectOptions (config "characteristicAbbrev") selected=system.damage.characteristic}}
         </select>
         {{#unless hideSL}}


### PR DESCRIPTION
Fix for https://github.com/moo-man/ImpMal-FoundryVTT/issues/155 by removing the clone() logic:
Now the modified traits and effects of the weapon are used in the damage calculation and not just the original traits of the weapon.
