### PR TITLE
Added Skills summary to NPC sheet (shows only those that have Advances)

### DIFF
--- a/static/templates/actor/npc/npc-main.hbs
+++ b/static/templates/actor/npc/npc-main.hbs
@@ -12,6 +12,29 @@
     </div>
 {{/if}}
 
+<div class="sheet-list">
+    <div class="list-header row-content">
+        <div class="list-name">{{localize "IMPMAL.Skills"}}</div>
+    </div>
+    <div class="list-content">
+        <div class="skills-summary">
+            {{#each system.skills}}
+            {{#if (gt this.advances 0)}}
+            <span>
+                <a class="rollable" data-action="rollTest" data-type="skill" data-key="{{@key}}">{{configLookup "skills" @key}} {{this.total}},</a>
+            </span>
+            {{/if}}
+            {{#each this.specialisations}}
+            {{#if (gt this.system.advances 0)}}
+            <span>
+                <a class="rollable" data-action="rollTest" data-type="skill" data-id="{{this.id}}">{{configLookup "skills" @../key}} ({{this.name}}) {{this.system.total}},</a>
+            </span>
+            {{/if}}
+            {{/each}}
+            {{/each}}
+        </div>
+    </div>
+</div>
 
 <div class="sheet-list">
     <div class="list-header row-content">

--- a/style/actor/_actor.scss
+++ b/style/actor/_actor.scss
@@ -189,6 +189,12 @@ body.theme-light .application.impmal.actor {
         gap: 0.5rem;
     }
 
+    .skill-summary {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
     .bar-section
     {
         flex: 5;


### PR DESCRIPTION
<img width="557" height="144" alt="image" src="https://github.com/user-attachments/assets/3313f0e1-5399-452d-924b-097e96b2a0bb" />

#180 - Just didn't add an option to show all skills, no matter if they have Advances or not.