### PR TITLE
Added a col to influence for Contacts, moved delete

### DIFF
--- a/static/templates/partials/influence.hbs
+++ b/static/templates/partials/influence.hbs
@@ -62,7 +62,7 @@
                     {{/each}}
                     {{#each this.sources}}
                         <div class="source row-content {{#if ../this.patron}}disabled inactive{{/if}}" data-index="{{@key}}">
-                            <a class="flex" data-action="deleteSource"><i class="fa-solid fa-xmark"></i></a>
+                            <div class="flex"></div>
                             <div class="small">
                                 <input type="number" data-saction="editSource" data-property="value" value="{{this.value}}">
                             </div>
@@ -72,6 +72,7 @@
                             <div class="flex large">
                                 <input type="text" data-saction="editSource" data-property="reason" value="{{this.reason}}">
                             </div>
+                            <a class="tiny" data-action="deleteSource"><i class="fa-solid fa-xmark"></i></a>
                         </div>
                     {{/each}}
                     {{#unless this.patron}}


### PR DESCRIPTION
<img width="711" height="337" alt="image" src="https://github.com/user-attachments/assets/443d5bf1-e4a5-4131-a299-fc8a1b0d501a" />

Added a col for user input of contacts. The second input is empty and isn't taken into account for anything, thus allowing the player to note Contact Influence. Also, I've moved the X since its too easy to click on it (you don't need to click X, just the whole row).

#112 #146 