### PR TITLE
Fix to Rend and repair armour when Rended

### DIFF
--- a/src/document/actor.js
+++ b/src/document/actor.js
@@ -282,20 +282,14 @@ export class ImpMalActor extends ImpMalDocumentMixin(WarhammerActor)
                 await Promise.all(item.parent.runScripts("preItemDamaged", args) || []);
                 value = Number(args.value);
             }
-
-            if (rend && value > 0 && item.system.rended[loc] != true)
-            {
-                updateObj["system.rended." + loc] = true;
-            }
             
             damage[loc] += Number(value);
             if (damage[loc] > item.system.armour) {
                 damage[loc] = item.system.armour;
             }
+
             if (damage[loc] < 0) damage[loc] = 0;
-            if (damage[loc] == 0) {
-                updateObj["system.rended." + loc] = false;
-            }
+
             if (damage[loc] == item.system.armour) {
                 updateObj["system.destroyed." + loc] = true;
             } else {

--- a/src/model/item/protection.js
+++ b/src/model/item/protection.js
@@ -16,7 +16,6 @@ export class ProtectionModel extends EquippableItemModel
         schema.armour = new fields.NumberField();
         schema.locations = new fields.EmbeddedDataField(HitLocationsModel);
         schema.damage = new fields.ObjectField({});
-        schema.rended = new fields.ObjectField({});
         schema.destroyed = new fields$d.ObjectField({});
         schema.slots = new fields.EmbeddedDataField(EquipSlots);
         schema.mods = new fields.EmbeddedDataField(ModListModel);
@@ -94,11 +93,7 @@ export class ProtectionModel extends EquippableItemModel
     {
         return Object.values(this.damage).some(i => i > 0);
     }
-
-    get isRended() 
-    {
-        return Object.values(this.rended).some(i => i);
-    }
+    
     get isDestroyed() {
         return Object.values(this.destroyed).some(i => i);
     }

--- a/src/sheet/items/types/protection.js
+++ b/src/sheet/items/types/protection.js
@@ -9,7 +9,6 @@ export default class ProtectionSheet extends IMItemSheet
       actions : {
           toggleMod: this._onToggleMod,
           clearDamage: this._onClearDamage,
-          clearRended: this._onClearRended
       }
     }
     
@@ -44,16 +43,6 @@ export default class ProtectionSheet extends IMItemSheet
                 damage[index] = 0;
             }
             this.item.update({ "system.damage": damage });
-        }
-    }
-
-    static _onClearRended(ev, target) {
-        let rended = foundry.utils.deepClone(this.item.system.rended);
-        if (rended) {
-            for (let index in rended) {
-                rended[index] = false;
-            }
-            this.item.update({ "system.rended": rended });
         }
     }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -126,7 +126,6 @@
     "IMPMAL.ChooseActor" : "Choose Actor",
     "IMPMAL.ChooseFaction" : "Choose Faction",
     "IMPMAL.Close" : "Close",
-    "IMPMAL.ClearRended" : "Clear Rended",
     "IMPMAL.ClearDamage" : "Clear Damage",
     "IMPMAL.Collapsed" : "Collapsed",
     "IMPMAL.Combat" : "Combat",

--- a/static/templates/actor/tabs/actor-combat.hbs
+++ b/static/templates/actor/tabs/actor-combat.hbs
@@ -294,7 +294,7 @@
                             {{#each this.items}}
                             <div class="protection-item" data-id="{{this.id}}">
                                 <label>– {{this.name}} </label>
-                                <a data-action="damageArmour" class="damage-armour {{#if (lookup this.system.damage ../this.key)}}damaged{{/if}}">{{#if (lookup this.system.destroyed ../this.key)}}Destroyed{{else}}{{calc this.system.armour "-" (lookup this.system.damage ../this.key)}}{{#if (lookup this.system.rended ../this.key)}}R{{/if}}{{/if}}</a>
+                                <a data-action="damageArmour" class="damage-armour {{#if (lookup this.system.damage ../this.key)}}damaged{{/if}}">{{#if (lookup this.system.destroyed ../this.key)}}Destroyed{{else}}{{calc this.system.armour "-" (lookup this.system.damage ../this.key)}}{{/if}}</a>
                                 {{!-- <div class="traits">{{this.system.traits.displayString}}
                             </div> --}}
                                 </div>

--- a/static/templates/item/types/protection.hbs
+++ b/static/templates/item/types/protection.hbs
@@ -8,9 +8,6 @@
     <!--TODO-->
     <div class="item-actions">
 
-        {{#if item.system.isRended}}
-            <button type="button" data-action="clearRended">{{localize "IMPMAL.ClearRended"}}</button>
-        {{/if}}
         {{#if item.system.isDamaged}}
             <button type="button" data-action="clearDamage">{{localize "IMPMAL.ClearDamage"}}</button>
         {{/if}}


### PR DESCRIPTION
Two isssues:
- Rended was never set to False, so if once a body part was Rended, it will never be Rended again, no matter if you "fix it".
- Rend applied a string, thus Rend (2) became "2" and when it was added to damage location, it became "02" instead. Setting it as Number fixes this issue.