### PR TITLE
Fix to Ranged Attack Fail -> Reroll Success -> No Opposed

### DIFF
--- a/src/system/tests/base/test-context.js
+++ b/src/system/tests/base/test-context.js
@@ -145,6 +145,15 @@ export class TestContext
             }
             else if (this.targetSpeakers.length) // If attacking
             {
+                // If a failed ranged roll auto-marked targets unopposed, allow a successful reroll to recreate opposed tests.
+                if (this.opposedFlagsAdded) {
+                    if (message?.system?.test?.item?.system?.attackType == "ranged" &&
+                        message?.system?.test?.result?.outcome == "success") {
+                        this.responses = {};
+                        this.opposedFlagsAdded = false;
+                    }
+                }
+
                 if (Object.keys(this.responses).length != this.targetSpeakers.length)
                 {
                     if (!fromUpdate)


### PR DESCRIPTION
Possible fix to Ranged Fail -> Reroll to Success -> No Opposed test. When ranged attack fails, it sets targets as unopposed and puts them in response. A reroll makes the test again and checks to make opposed, so with opposedFlagsAdded set to true, we might catch a successful ranged test and delete responses, to make this work.

#86 