### PR TITLE
Modification Traits lost on clone

### DIFF
--- a/src/system/tests/attack/attack-test.js
+++ b/src/system/tests/attack/attack-test.js
@@ -37,7 +37,34 @@ export class AttackTest extends SkillTest
 
     get itemTraits() 
     {
-        return (this.item.system.traits || this.item.system.attack?.traits)?.clone();
+        let cloned = (this.item.system.traits || this.item.system.attack?.traits)?.clone();
+        if (this.item.system.mods?.list)
+            for (let mod of this.item.system.mods.documents) {
+                // Add traits
+                cloned.combine(mod.system.addedTraits);
+
+                // Remove Traits
+                cloned.list = cloned.list.filter(t => {
+                    let removed = mod.system.removedTraits.has(t.key);
+                    if (removed) {
+                        if (Number.isNumeric(t.value)) {
+                            t.value -= (removed.value || 0);
+                        }
+
+                        // If boolean trait, or trait has negative value (after subtracting above), remove it
+                        if (!Number.isNumeric(t.value) || t.value <= 0) {
+                            return false;
+                        }
+                        else {
+                            return true;
+                        }
+                    }
+                    else {
+                        return true;
+                    }
+                });
+            }
+        return cloned;
     }
 
 


### PR DESCRIPTION
#155 

Made that the cloned traits go through the modification list of the item and are added to the itemTraits for attackTest, based on applyModifications function.

