### PR TITLE
Added that the Dead effect is overlay.

### DIFF
--- a/src/system/config.js
+++ b/src/system/config.js
@@ -1457,7 +1457,12 @@ const IMPMAL = {
             img: "systems/impmal/assets/icons/conditions/dead.svg",
             id: "dead",
             statuses : ["dead"],
-            name: "IMPMAL.Dead"
+            name: "IMPMAL.Dead",
+            flags: {
+                core: {
+                    overlay: true
+                }
+            }
         },
     ],
 


### PR DESCRIPTION
Without the flag, whenever you add Dead effect to a token (be it from status effects, the sheet or some code), it will be only one of the effects on the token. Making it very hard to discern who is alive in a pile of corpses. This issue doesn't exist when you apply Defeated from the Encounter tab.

Giving the effect the overlay true flag should fix this issue.