### PR TITLE
Fix Bleeding and Ablaze Damage with Flak Armour

### DIFF
--- a/src/system/config.js
+++ b/src/system/config.js
@@ -1023,6 +1023,7 @@ const IMPMAL = {
                     label : "Reduce Damage",
                     trigger : "preTakeDamage",
                     script : `
+                    if (!args.opposed) return;
                     let weapon = args.opposed.attackerTest.item
                     if (
                         args.opposed && weapon?.system.category == "grenadesExplosives" &&  // Grenade or Explosive


### PR DESCRIPTION
Bleeding, ablaze and possible other damage sources where not working with Flak Armour, because the Flak script crashes when the damage comes from a non-opposed source. Added return condition to prevent crash.